### PR TITLE
【レイアウト変更】ヘッダーナビゲーションのレイアウト調整

### DIFF
--- a/attendance.html
+++ b/attendance.html
@@ -1,155 +1,203 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>出欠管理 - 受講生管理システム</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="assets/css/style.css">
-</head>
-<body>
-  <div class="app-container" id="app">
-    <main class="main-content" id="main-content">
-      <div class="page-content">
-        <div class="flex justify-between items-center mb-6">
-          <div>
-            <h1 class="page-title">出欠管理</h1>
-            <p class="page-description" style="margin-bottom: 0;">各講座の出欠状況の記録と確認</p>
-          </div>
-        </div>
-
-        <div class="card mb-6">
-          <div class="card-body">
-            <div class="grid grid-cols-4 gap-4">
-              <div class="form-group" style="margin-bottom: 0;">
-                <label class="form-label">対象講座</label>
-                <select class="form-control">
-                  <option value="1">Web開発マスターコース</option>
-                  <option value="2">Pythonデータサイエンス</option>
-                </select>
-              </div>
-              <div class="form-group" style="margin-bottom: 0;">
-                <label class="form-label">講義日（回数）</label>
-                <select class="form-control">
-                  <option value="1">第8回 (2024/05/23)</option>
-                  <option value="2">第7回 (2024/05/21)</option>
-                  <option value="3">第6回 (2024/05/16)</option>
-                </select>
-              </div>
-              <div class="flex items-end mb-0">
-                <button class="btn btn-secondary w-full"><i class="fas fa-sync"></i> 表示更新</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="card">
-          <div class="card-header flex justify-between items-center">
-            <h2 class="card-title">Web開発マスターコース - 第8回 出欠簿</h2>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>出欠管理 - 受講生管理システム(レイアウト修正)</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <div class="app-container" id="app">
+      <main class="main-content" id="main-content">
+        <div class="page-content">
+          <div class="flex justify-between items-center mb-6">
             <div>
-              <button class="btn btn-primary"><i class="fas fa-save"></i> 状態を保存</button>
+              <h1 class="page-title">出欠管理</h1>
+              <p class="page-description" style="margin-bottom: 0">各講座の出欠状況の記録と確認</p>
             </div>
           </div>
-          <div class="table-responsive">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>受講生名</th>
-                  <th>出欠状況</th>
-                  <th>備考（遅刻理由など）</th>
-                  <th>前回までの出席率</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    <div class="flex items-center">
-                      <div class="avatar" style="width: 32px; height: 32px; font-size: 0.8rem; margin-right: 0.75rem; background-color: #3b82f6;">山</div>
-                      山田 太郎
-                    </div>
-                  </td>
-                  <td>
-                    <select class="form-control" style="width: 150px; background-color: #d1fae5;">
-                      <option value="present" selected>出席</option>
-                      <option value="absent">欠席</option>
-                      <option value="late">遅刻</option>
-                      <option value="leave_early">早退</option>
-                    </select>
-                  </td>
-                  <td>
-                    <input type="text" class="form-control" placeholder="特記事項なし">
-                  </td>
-                  <td>100% (7/7)</td>
-                </tr>
-                <tr>
-                  <td>
-                    <div class="flex items-center">
-                      <div class="avatar" style="width: 32px; height: 32px; font-size: 0.8rem; margin-right: 0.75rem; background-color: #10b981;">鈴</div>
-                      鈴木 一郎
-                    </div>
-                  </td>
-                  <td>
-                    <select class="form-control" style="width: 150px; background-color: #d1fae5;">
-                      <option value="present" selected>出席</option>
-                      <option value="absent">欠席</option>
-                      <option value="late">遅刻</option>
-                      <option value="leave_early">早退</option>
-                    </select>
-                  </td>
-                  <td>
-                    <input type="text" class="form-control">
-                  </td>
-                  <td>85% (6/7)</td>
-                </tr>
-                <tr>
-                  <td>
-                    <div class="flex items-center">
-                      <div class="avatar" style="width: 32px; height: 32px; font-size: 0.8rem; margin-right: 0.75rem; background-color: #ec4899;">田</div>
-                      田中 美咲
-                    </div>
-                  </td>
-                  <td>
-                    <select class="form-control" style="width: 150px; background-color: #fee2e2;">
-                      <option value="present">出席</option>
-                      <option value="absent" selected>欠席</option>
-                      <option value="late">遅刻</option>
-                      <option value="leave_early">早退</option>
-                    </select>
-                  </td>
-                  <td>
-                    <input type="text" class="form-control" value="体調不良のため事前連絡あり">
-                  </td>
-                  <td>85% (6/7)</td>
-                </tr>
-                <tr>
-                  <td>
-                    <div class="flex items-center">
-                      <div class="avatar" style="width: 32px; height: 32px; font-size: 0.8rem; margin-right: 0.75rem; background-color: #f59e0b;">高</div>
-                      高橋 健太
-                    </div>
-                  </td>
-                  <td>
-                    <select class="form-control" style="width: 150px; background-color: #fef3c7;">
-                      <option value="present">出席</option>
-                      <option value="absent">欠席</option>
-                      <option value="late" selected>遅刻</option>
-                      <option value="leave_early">早退</option>
-                    </select>
-                  </td>
-                  <td>
-                    <input type="text" class="form-control" value="電車遅延のため15分遅れ">
-                  </td>
-                  <td>100% (7/7)</td>
-                </tr>
-              </tbody>
-            </table>
+
+          <div class="card mb-6">
+            <div class="card-body">
+              <div class="grid grid-cols-4 gap-4">
+                <div class="form-group" style="margin-bottom: 0">
+                  <label class="form-label">対象講座</label>
+                  <select class="form-control">
+                    <option value="1">Web開発マスターコース</option>
+                    <option value="2">Pythonデータサイエンス</option>
+                  </select>
+                </div>
+                <div class="form-group" style="margin-bottom: 0">
+                  <label class="form-label">講義日（回数）</label>
+                  <select class="form-control">
+                    <option value="1">第8回 (2024/05/23)</option>
+                    <option value="2">第7回 (2024/05/21)</option>
+                    <option value="3">第6回 (2024/05/16)</option>
+                  </select>
+                </div>
+                <div class="flex items-end mb-0">
+                  <button class="btn btn-secondary w-full">
+                    <i class="fas fa-sync"></i> 表示更新
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header flex justify-between items-center">
+              <h2 class="card-title">Web開発マスターコース - 第8回 出欠簿</h2>
+              <div>
+                <button class="btn btn-primary"><i class="fas fa-save"></i> 状態を保存</button>
+              </div>
+            </div>
+            <div class="table-responsive">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>受講生名</th>
+                    <th>出欠状況</th>
+                    <th>備考（遅刻理由など）</th>
+                    <th>前回までの出席率</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="flex items-center">
+                        <div
+                          class="avatar"
+                          style="
+                            width: 32px;
+                            height: 32px;
+                            font-size: 0.8rem;
+                            margin-right: 0.75rem;
+                            background-color: #3b82f6;
+                          "
+                        >
+                          山
+                        </div>
+                        山田 太郎
+                      </div>
+                    </td>
+                    <td>
+                      <select class="form-control" style="width: 150px; background-color: #d1fae5">
+                        <option value="present" selected>出席</option>
+                        <option value="absent">欠席</option>
+                        <option value="late">遅刻</option>
+                        <option value="leave_early">早退</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input type="text" class="form-control" placeholder="特記事項なし" />
+                    </td>
+                    <td>100% (7/7)</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="flex items-center">
+                        <div
+                          class="avatar"
+                          style="
+                            width: 32px;
+                            height: 32px;
+                            font-size: 0.8rem;
+                            margin-right: 0.75rem;
+                            background-color: #10b981;
+                          "
+                        >
+                          鈴
+                        </div>
+                        鈴木 一郎
+                      </div>
+                    </td>
+                    <td>
+                      <select class="form-control" style="width: 150px; background-color: #d1fae5">
+                        <option value="present" selected>出席</option>
+                        <option value="absent">欠席</option>
+                        <option value="late">遅刻</option>
+                        <option value="leave_early">早退</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input type="text" class="form-control" />
+                    </td>
+                    <td>85% (6/7)</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="flex items-center">
+                        <div
+                          class="avatar"
+                          style="
+                            width: 32px;
+                            height: 32px;
+                            font-size: 0.8rem;
+                            margin-right: 0.75rem;
+                            background-color: #ec4899;
+                          "
+                        >
+                          田
+                        </div>
+                        田中 美咲
+                      </div>
+                    </td>
+                    <td>
+                      <select class="form-control" style="width: 150px; background-color: #fee2e2">
+                        <option value="present">出席</option>
+                        <option value="absent" selected>欠席</option>
+                        <option value="late">遅刻</option>
+                        <option value="leave_early">早退</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input type="text" class="form-control" value="体調不良のため事前連絡あり" />
+                    </td>
+                    <td>85% (6/7)</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="flex items-center">
+                        <div
+                          class="avatar"
+                          style="
+                            width: 32px;
+                            height: 32px;
+                            font-size: 0.8rem;
+                            margin-right: 0.75rem;
+                            background-color: #f59e0b;
+                          "
+                        >
+                          高
+                        </div>
+                        高橋 健太
+                      </div>
+                    </td>
+                    <td>
+                      <select class="form-control" style="width: 150px; background-color: #fef3c7">
+                        <option value="present">出席</option>
+                        <option value="absent">欠席</option>
+                        <option value="late" selected>遅刻</option>
+                        <option value="leave_early">早退</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input type="text" class="form-control" value="電車遅延のため15分遅れ" />
+                    </td>
+                    <td>100% (7/7)</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
+      </main>
+    </div>
 
-      </div>
-    </main>
-  </div>
-
-  <script src="assets/js/main.js"></script>
-</body>
+    <script src="assets/js/main.js"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <!-- TODO: ヘッダーナビゲーションのレイアウト調整 (Issue #1) -->
   <title>受講生管理システム</title>
   <script>
     // Redirect to login page


### PR DESCRIPTION
## 対応内容
ヘッダーナビゲーションのレイアウトをレスポンシブ対応で改善した。

## 変更点
- ナビゲーションアイテムの間隔を均等に調整
- - SP時はハンバーガーメニューに切り替え
- - ロゴ位置を左寄せに統一
## レビューポイント
- 各ブレークポイントでの表示確認
- - デザインカンプとの一致確認
Closes #1