### PR TITLE
セレクトボックスに事務員のみを追加

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -31,6 +31,7 @@
                 <option value="">配信対象: すべて</option>
                 <option value="students">受講生のみ</option>
                 <option value="instructors">講師のみ</option>
+                <option value="clerk">事務員のみ</option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
対応
selectタグ内のoptionに新たに追加して修正をした

変更点
お知らせ管理画面の配信対象のセレクトボックスに事務員のみを追加した

レビューポイント
お知らせ管理画面の配信対象セレクトボックスに新たに選択肢が増えているか

#11 